### PR TITLE
add py-requirements submit option

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -356,15 +356,18 @@ object SparkSubmit {
         args.childArgs = ArrayBuffer(args.primaryResource, args.pyFiles) ++ args.childArgs
         if (clusterManager != YARN) {
           // The YARN backend distributes the primary file differently, so don't merge it.
-          args.files = mergeFileLists(args.files, args.primaryResource)
+          args.files = mergeFileLists(args.files, args.primaryResource, args.pyRequirements)
         }
       }
       if (clusterManager != YARN) {
         // The YARN backend handles python files differently, so don't merge the lists.
-        args.files = mergeFileLists(args.files, args.pyFiles)
+        args.files = mergeFileLists(args.files, args.pyFiles, args.pyRequirements)
       }
       if (args.pyFiles != null) {
         sysProps("spark.submit.pyFiles") = args.pyFiles
+      }
+      if (args.pyRequirements != null) {
+        sysProps("spark.submit.pyRequirements") = args.pyRequirements
       }
     }
 
@@ -542,6 +545,10 @@ object SparkSubmit {
       if (args.pyFiles != null) {
         sysProps("spark.submit.pyFiles") = args.pyFiles
       }
+
+      if (args.pyRequirements != null) {
+        sysProps("spark.submit.pyRequirements") = args.pyRequirements
+      }
     }
 
     // assure a keytab is available from any place in a JVM
@@ -592,6 +599,9 @@ object SparkSubmit {
         childArgs += (args.primaryResource, "")
         if (args.pyFiles != null) {
           sysProps("spark.submit.pyFiles") = args.pyFiles
+        }
+        if (args.pyRequirements != null) {
+          sysProps("spark.submit.pyRequirements") = args.pyRequirements
         }
       } else {
         childArgs += (args.primaryResource, args.mainClass)

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
@@ -64,6 +64,7 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
   var verbose: Boolean = false
   var isPython: Boolean = false
   var pyFiles: String = null
+  var pyRequirements: String = null
   var isR: Boolean = false
   var action: SparkSubmitAction = null
   val sparkProperties: HashMap[String, String] = new HashMap[String, String]()
@@ -304,6 +305,7 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
     |  numExecutors            $numExecutors
     |  files                   $files
     |  pyFiles                 $pyFiles
+    |  pyRequiremenst          $pyRequirements
     |  archives                $archives
     |  mainClass               $mainClass
     |  primaryResource         $primaryResource
@@ -394,6 +396,9 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
 
       case PY_FILES =>
         pyFiles = Utils.resolveURIs(value)
+
+      case PY_REQUIREMENTS =>
+        pyRequirements = Utils.resolveURIs(value)
 
       case ARCHIVES =>
         archives = Utils.resolveURIs(value)
@@ -505,6 +510,8 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
         |                              search for the maven coordinates given with --packages.
         |  --py-files PY_FILES         Comma-separated list of .zip, .egg, or .py files to place
         |                              on the PYTHONPATH for Python apps.
+        |  --py-requirements REQS      Pip requirements file with dependencies that will be fetched
+        |                              and placed on PYTHONPATH
         |  --files FILES               Comma-separated list of files to be placed in the working
         |                              directory of each executor.
         |

--- a/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitOptionParser.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitOptionParser.java
@@ -55,6 +55,7 @@ class SparkSubmitOptionParser {
   protected final String PROPERTIES_FILE = "--properties-file";
   protected final String PROXY_USER = "--proxy-user";
   protected final String PY_FILES = "--py-files";
+  protected final String PY_REQUIREMENTS = "--py-requirements";
   protected final String REPOSITORIES = "--repositories";
   protected final String STATUS = "--status";
   protected final String TOTAL_EXECUTOR_CORES = "--total-executor-cores";

--- a/python/pyspark/context.py
+++ b/python/pyspark/context.py
@@ -209,6 +209,12 @@ class SparkContext(object):
                     self._python_includes.append(filename)
                     sys.path.insert(1, os.path.join(SparkFiles.getRootDirectory(), filename))
 
+        # Apply requirements file set by spark-submit.
+        for path in self._conf.get("spark.submit.pyRequirements", "").split(","):
+            if path != "":
+                (dirname, filename) = os.path.split(path)
+                self.addRequirementsFile(os.path.join(SparkFiles.getRootDirectory(), filename))
+
         # Create a temporary directory inside spark.local.dir:
         local_dir = self._jvm.org.apache.spark.util.Utils.getLocalDir(self._jsc.sc().conf())
         self._temp_dir = \


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add --py-requirements option to spark-submit that takes list of comma delimited pip requirements file names and loads them upon pyspark context initialization
## How was this patch tested?

Unit tests
